### PR TITLE
Add support for CUDA>=12.5

### DIFF
--- a/include/cuda_utils.h
+++ b/include/cuda_utils.h
@@ -13,7 +13,18 @@
 #ifndef CUDA_UTILS_H
 #define CUDA_UTILS_H
 
+#if __has_include(<nvtx3/nvToolsExt.h>)
+#include <nvtx3/nvToolsExt.h>
+#else
 #include <nvToolsExt.h>
+#endif
+#if __has_include(<nvtx3/nvToolsExtCuda.h>)
+#include <nvtx3/nvToolsExtCuda.h>
+#else
+#include <nvToolsExtCuda.h>
+#endif
+
+
 #include <stdio.h>
 #include <vector>
 

--- a/src/cuda_utils.cu
+++ b/src/cuda_utils.cu
@@ -15,7 +15,6 @@
 #include <cuda.h>
 #include <fstream>
 #include <iostream>
-#include <nvToolsExtCuda.h>
 #include <utility>
 
 //----------------------------------------------------------------------------------------


### PR DESCRIPTION
From #1 

Fixes issue due to `device_vector` including the newer nvtx3 and breaking code that includes the older version of nvTools.

Could you please check that I didn't break the install with older CUDA versions?